### PR TITLE
Fix hpc-coveralls configuration, enable coverage only in GHC 7.10.1 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - travis_retry cabal update
- - [ "$COVERAGE" = "1" ] && cabal install hpc-coveralls
+ - "[ \"$COVERAGE\" = \"1\" ] && cabal install hpc-coveralls"
  - cabal install --only-dependencies --enable-tests --enable-benchmarks
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
@@ -65,4 +65,4 @@ script:
    fi
 
 after_script:
- - [ "$COVERAGE" = "1" ] && hpc-coveralls TestSign --exclude-dir=test
+ - "[ \"$COVERAGE\" = \"1\" ] && hpc-coveralls TestSign --exclude-dir=test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,6 @@ script:
    fi
 
 after_script:
-  - travis_retry sudo apt-get install tree
-  - tree dist/ # temporarily needed to investigate issue with hpc-coveralls
+ - travis_retry sudo apt-get install tree
+ - tree dist/ # temporarily needed to investigate issue with hpc-coveralls
  - "[ -n \"$COVERAGE\" ] && hpc-coveralls TestSign --exclude-dir=test || true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - travis_retry cabal update
- - "[ -n \"$COVERAGE\" ] && cabal install hpc-coveralls" || true
+ - "[ -n \"$COVERAGE\" ] && cabal install hpc-coveralls || true"
  - cabal install --only-dependencies --enable-tests --enable-benchmarks
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
@@ -65,4 +65,4 @@ script:
    fi
 
 after_script:
- - "[ -n \"$COVERAGE\" ] && hpc-coveralls TestSign --exclude-dir=test" || true
+ - "[ -n \"$COVERAGE\" ] && hpc-coveralls TestSign --exclude-dir=test || true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - travis_retry cabal update
- - "[ \"$COVERAGE\" = \"1\" ] && cabal install hpc-coveralls"
+ - "[ -n \"$COVERAGE\" ] && cabal install hpc-coveralls" || true
  - cabal install --only-dependencies --enable-tests --enable-benchmarks
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
@@ -65,4 +65,4 @@ script:
    fi
 
 after_script:
- - "[ \"$COVERAGE\" = \"1\" ] && hpc-coveralls TestSign --exclude-dir=test"
+ - "[ -n \"$COVERAGE\" ] && hpc-coveralls TestSign --exclude-dir=test" || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,6 @@ script:
    fi
 
 after_script:
+  - travis_retry sudo apt-get install tree
+  - tree dist/ # temporarily needed to investigate issue with hpc-coveralls
  - "[ -n \"$COVERAGE\" ] && hpc-coveralls TestSign --exclude-dir=test || true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
  - CABALVER=1.18 GHCVER=7.6.3
 # - CABALVER=1.18 GHCVER=7.8.1  # see note about Alex/Happy for GHC >= 7.8
 # - CABALVER=1.18 GHCVER=7.8.2
- - CABALVER=1.18 GHCVER=7.8.3
- - CABALVER=1.22 GHCVER=7.10.1 COVERAGE=1
+ - CABALVER=1.18 GHCVER=7.8.3 COVERAGE=1
+ - CABALVER=1.22 GHCVER=7.10.1
 # - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
 
 matrix:
@@ -48,7 +48,7 @@ install:
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks -v2 $([ "$COVERAGE" = "1" ] && echo "--enable-coverage") # -v2 provides useful information for debugging
+ - cabal configure --enable-tests --enable-benchmarks -v2 $([ "$COVERAGE" = "1" ] && echo "--enable-library-coverage") # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test
  - cabal check

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 # - CABALVER=1.18 GHCVER=7.8.1  # see note about Alex/Happy for GHC >= 7.8
 # - CABALVER=1.18 GHCVER=7.8.2
  - CABALVER=1.18 GHCVER=7.8.3
- - CABALVER=1.22 GHCVER=7.10.1
+ - CABALVER=1.22 GHCVER=7.10.1 COVERAGE=1
 # - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
 
 matrix:
@@ -42,16 +42,15 @@ install:
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - travis_retry cabal update
- - cabal install hpc-coveralls
+ - [ "$COVERAGE" = "1" ] && cabal install hpc-coveralls
  - cabal install --only-dependencies --enable-tests --enable-benchmarks
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-library-coverage --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal configure --enable-tests --enable-benchmarks -v2 $([ "$COVERAGE" = "1" ] && echo "--enable-coverage") # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
-# - cabal test
- - run-cabal-test
+ - cabal test
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
 
@@ -66,4 +65,4 @@ script:
    fi
 
 after_script:
- - hpc-coveralls TestSign
+ - [ "$COVERAGE" = "1" ] && hpc-coveralls TestSign --exclude-dir=test


### PR DESCRIPTION
I've fixed travis configuration file to only enable hpc-coveralls in ghc 7.8.x build as I've noticed that the current version is not compatible with ghc 7.10.x (I'm planning to fix this soon: https://github.com/guillaume-nargeot/hpc-coveralls/issues/38).

Unfortunately, even after the configuration fix, it seems that hpc-coveralls still cannot find hpc data files although it should.
I need to investigate a little more why these files are not where they are expected to be.
